### PR TITLE
Add note about an error to check for understanding

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ hello("Guido")()
 <p>While there's a <code>print()</code> statement inside of the
 <code>greet()</code> function, it won't be interpreted if <code>greet()</code>
 is not invoked.</p>
+  
+  <p>Also, note that <code>hello("Guido")()</code> is invoking the return value of the function. So, if we don't return a function from hello but instead return nothing, we'd then also get a TypeError: 'NoneType' object is not callable</p>
 
 </p>
 </details>


### PR DESCRIPTION
The first check for understanding asks what will happen if we leave out `return greet` from the hello function. 

As the question is phrased, if we do that and keep the code above:
```python
hello("Guido")()
```
We'll end up with the print but then also a TypeError because we'll have removed the returned function and are now attempting to invoke 'None'